### PR TITLE
appveyor CI

### DIFF
--- a/IndentAsPrevious.cpp
+++ b/IndentAsPrevious.cpp
@@ -63,7 +63,7 @@ bool setCommand(size_t index, TCHAR *cmdName, PFUNCPLUGINCMD pFunc, ShortcutKey 
 		return false;
 	}
 
-	StringCchCopy(funcItem[index]._itemName, sizeof(funcItem[index]._itemName), cmdName);
+	StringCchCopy(funcItem[index]._itemName, sizeof(funcItem[index]._itemName)/sizeof(TCHAR), cmdName);
 	funcItem[index]._pFunc = pFunc;
 	funcItem[index]._init2Check = checkOnInit;
 	funcItem[index]._pShKey = sk;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,72 @@
+version: 1.0.1.{build}
+image: Visual Studio 2015
+
+
+environment:
+  matrix:
+    #- PlatformToolset: v120_xp
+    - PlatformToolset: v140_xp
+
+platform:
+    - x64
+    - Win32
+
+configuration:
+    - u_release
+    - u_debug
+    - a_release
+    - a_debug
+
+
+install:
+    - if "%platform%"=="x64" set archi=amd64
+    - if "%platform%"=="Win32" set archi=x86
+    - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %archi%
+
+build:
+    parallel: true                  # enable MSBuild parallel builds
+    verbosity: minimal
+
+build_script:
+    - cd "%APPVEYOR_BUILD_FOLDER%"
+    - msbuild IndentAsPrevious.sln /m /p:configuration="%configuration%" /p:platform="%platform%" /p:PlatformToolset="%PlatformToolset%"
+
+after_build:
+    - cd "%APPVEYOR_BUILD_FOLDER%"
+    - ps: >-
+
+        if ($env:PLATFORM -eq "x64") {
+            #Push-AppveyorArtifact "out\$env:PLATFORM\$env:CONFIGURATION\IndentAsPrevious.dll" -FileName IndentAsPrevious.dll
+        }
+
+        if ($env:PLATFORM -eq "Win32" ) {
+            #Push-AppveyorArtifact "out\$env:CONFIGURATION\IndentAsPrevious.dll" -FileName IndentAsPrevious.dll
+        }
+
+        if ($($env:APPVEYOR_REPO_TAG) -eq "true" -and $env:CONFIGURATION -eq "u_release" -and $env:PLATFORMTOOLSET -eq "v140_xp") {
+            if($env:PLATFORM -eq "x64"){
+            $ZipFileName = "IndentAsPrevious_$($env:APPVEYOR_REPO_TAG_NAME)_x64.zip"
+            7z a $ZipFileName out\$env:PLATFORM\$env:CONFIGURATION\IndentAsPrevious.dll
+            }
+            if($env:PLATFORM -eq "Win32"){
+            $ZipFileName = "IndentAsPrevious_$($env:APPVEYOR_REPO_TAG_NAME)_x86.zip"
+            7z a $ZipFileName out\$env:CONFIGURATION\IndentAsPrevious.dll
+            }
+        }
+
+artifacts:
+  - path: IndentAsPrevious_*.zip
+    name: releases
+
+deploy:
+    provider: GitHub
+    auth_token:
+        secure: !!TODO, see https://www.appveyor.com/docs/deployment/github/#provider-settings!!
+    artifact: releases
+    draft: false
+    prerelease: false
+    force_update: true
+    on:
+        appveyor_repo_tag: true
+        PlatformToolset: v140_xp
+        configuration: Release


### PR DESCRIPTION
- initial appveyor.yml config, could be adapted regarding published dlls and github deployment on tagging, example build see https://ci.appveyor.com/project/chcg/indentasprevious/build/1.0.1.2
- corrected VS analysis issue:
indentasprevious\indentasprevious.cpp(67): warning C6386: Buffer overrun while writing to 'funcItem[index]._itemName':  the writable size is '128' bytes, but '256' bytes might be written.


Further hints:
- open VS analysis issues:
-- indentasprevious\indentasprevious.cpp(26): warning C6215: Cast between semantically different integer types:  a Boolean type to HRESULT.
-- indentasprevious\indentasprevious.cpp(30): warning C6215: Cast between semantically different integer types:  a Boolean type to HRESULT.
, see https://msdn.microsoft.com/de-de/library/windows/desktop/bb773565(v=vs.85).aspx for the return value
- maybe consider to update "npp_plugin_sdk" header files with data from https://github.com/npp-plugins/plugintemplate, 
- see https://ci.appveyor.com/project/chcg/indentasprevious/build/1.0.1.1, platform toolset v120_xp used by N++ itself doesn't build for x64